### PR TITLE
BRIDGE-261 Add ability to set additional flags via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ the table below for reference.
 
 | Variable | Description | Default | Required |
 | --- | --- | --- | --- |
+| AV_ADDITIONAL_SCAN_FLAGS | Additional flags to be passed to the `clamscan` command |  | No |
 | AV_DEFINITION_S3_BUCKET | Bucket containing antivirus definition files |  | Yes |
 | AV_DEFINITION_S3_PREFIX | Prefix for antivirus definition files | clamav_defs | No |
 | AV_DEFINITION_PATH | Path containing files at runtime | /tmp/clamav_defs | No |

--- a/clamav.py
+++ b/clamav.py
@@ -32,6 +32,7 @@ from common import AV_SIGNATURE_OK
 from common import AV_SIGNATURE_UNKNOWN
 from common import AV_STATUS_CLEAN
 from common import AV_STATUS_INFECTED
+from common import AV_ADDITIONAL_SCAN_FLAGS
 from common import CLAMAVLIB_PATH
 from common import CLAMSCAN_PATH
 from common import FRESHCLAM_PATH
@@ -183,9 +184,23 @@ def scan_output_to_json(output):
 def scan_file(path):
     av_env = os.environ.copy()
     av_env["LD_LIBRARY_PATH"] = CLAMAVLIB_PATH
+    process_args = [
+        CLAMSCAN_PATH,
+        "-v",
+        "-a",
+        "--stdout",
+        "-d",
+        AV_DEFINITION_PATH,
+        path,
+    ]
+
+    # Insert additional flags into argument list if present
+    if AV_ADDITIONAL_SCAN_FLAGS:
+        process_args.insert(1, AV_ADDITIONAL_SCAN_FLAGS)
+
     print("Starting clamscan of %s." % path)
     av_proc = subprocess.Popen(
-        [CLAMSCAN_PATH, "-v", "-a", "--stdout", "-d", AV_DEFINITION_PATH, path],
+        process_args,
         stderr=subprocess.STDOUT,
         stdout=subprocess.PIPE,
         env=av_env,

--- a/common.py
+++ b/common.py
@@ -18,6 +18,7 @@ import datetime
 import os
 import os.path
 
+AV_ADDITIONAL_SCAN_FLAGS = os.getenv("AV_ADDITIONAL_SCAN_FLAGS")
 AV_DEFINITION_S3_BUCKET = os.getenv("AV_DEFINITION_S3_BUCKET")
 AV_DEFINITION_S3_PREFIX = os.getenv("AV_DEFINITION_S3_PREFIX", "clamav_defs")
 AV_DEFINITION_PATH = os.getenv("AV_DEFINITION_PATH", "/tmp/clamav_defs")


### PR DESCRIPTION
This pull request adds an environment variable than can be set to pass through additional flags to the `clamscan` process.

Within the `clamav.py` file, the flag is only added when a value is set, to prevent passing a `None` causing `subprocess.Popen()` to break.