### PR TITLE
MC3-47 Update remote docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
     working_directory: ~/src
     steps:
       - setup_remote_docker:
-          version: 20.10.14
+          version: default
       - aws-cli/install
       - checkout
       - run:


### PR DESCRIPTION
Update to a non deprecated version of the remote docker image. 

https://discuss.circleci.com/t/remote-docker-image-deprecations-and-eol-for-2024/50176